### PR TITLE
db: pre-create collections to fix WriteConflict on concurrent AddLog

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -88,10 +88,15 @@ func (s *service) Run(ctx context.Context) (err error) {
 	if err = s.client.Ping(pingCtx, readpref.Primary()); err != nil {
 		return err
 	}
-	s.logColl = s.client.Database(s.conf.Database).Collection(s.conf.LogCollection)
+	db := s.client.Database(s.conf.Database)
+	s.logColl = db.Collection(s.conf.LogCollection)
 	s.running = true
-	s.settingsColl = s.client.Database(s.conf.Database).Collection(settingsColl)
-	s.payloadColl = s.client.Database(s.conf.Database).Collection(payloadColl)
+	s.settingsColl = db.Collection(settingsColl)
+	s.payloadColl = db.Collection(payloadColl)
+
+	if err = s.ensureCollections(ctx, db); err != nil {
+		return err
+	}
 
 	if err = s.runMigrations(ctx); err != nil {
 		return err
@@ -99,6 +104,25 @@ func (s *service) Run(ctx context.Context) (err error) {
 	if s.changeReceiver != nil {
 		if err = s.runStreamListener(ctx); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// ensureCollections explicitly creates collections that are used inside
+// transactions. MongoDB cannot implicitly create collections within
+// multi-document transactions; concurrent attempts to do so result in
+// WriteConflict errors. Creating them upfront eliminates the race.
+func (s *service) ensureCollections(ctx context.Context, db *mongo.Database) error {
+	for _, name := range []string{s.conf.LogCollection, settingsColl, payloadColl} {
+		if err := db.CreateCollection(ctx, name); err != nil {
+			// MongoDB < 7.0 returns NamespaceExists (code 48) when the
+			// collection already exists. Starting with 7.0 the server
+			// returns success instead.
+			if cmdErr, ok := err.(mongo.CommandError); ok && cmdErr.Code == 48 {
+				continue
+			}
+			return fmt.Errorf("create collection %q: %w", name, err)
 		}
 	}
 	return nil
@@ -138,7 +162,6 @@ func (s *service) AddLog(ctx context.Context, l consensus.Log) (err error) {
 		}
 		return nil
 	})
-
 }
 
 type findLogQuery struct {
@@ -229,10 +252,10 @@ func (s *service) FetchLog(ctx context.Context, logId, afterRecordId string) (l 
 }
 
 func (s *service) injectPayloads(ctx context.Context, l consensus.Log, afterRecordId string) (res consensus.Log, err error) {
-	var payloads = make(map[string]int, len(l.Records))
+	payloads := make(map[string]int, len(l.Records))
 	res = l
 	res.Records = l.Records[:0]
-	var add = afterRecordId == ""
+	add := afterRecordId == ""
 	for _, record := range l.Records {
 		if add {
 			res.Records = append(res.Records, record)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -221,6 +222,49 @@ func TestService_SetDeletionId(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "123", logId)
 	})
+}
+
+// TestService_AddLog_ConcurrentOnFreshDB verifies that concurrent AddLog
+// calls succeed even when the database is fresh and collections have not
+// been created yet. Without explicit collection pre-creation in Run(),
+// MongoDB raises a WriteConflict because concurrent transactions attempt
+// to implicitly create the "payload" collection at the same time.
+func TestService_AddLog_ConcurrentOnFreshDB(t *testing.T) {
+	fx := newFixture(t, nil)
+	defer fx.Finish(t)
+
+	// Simulate a fresh install: drop all collections so the
+	// "payload" collection does not exist yet.
+	s := fx.Service.(*service)
+	_ = s.logColl.Drop(ctx)
+	_ = s.settingsColl.Drop(ctx)
+	_ = s.payloadColl.Drop(ctx)
+
+	// Re-run ensureCollections as Run() would on a real fresh start.
+	db := s.client.Database(s.conf.Database)
+	if err := s.ensureCollections(ctx, db); err != nil {
+		t.Fatalf("ensureCollections: %v", err)
+	}
+
+	const n = 5
+	errs := make(chan error, n)
+
+	for i := range n {
+		go func() {
+			errs <- fx.AddLog(ctx, consensus.Log{
+				Id: fmt.Sprintf("concurrent-log-%d", i),
+				Records: []consensus.Record{{
+					Id:      fmt.Sprintf("rec-%d", i),
+					Payload: []byte("data"),
+				}},
+			})
+		}()
+	}
+
+	for i := range n {
+		err := <-errs
+		assert.NoError(t, err, "AddLog #%d should succeed", i)
+	}
 }
 
 func newFixture(t *testing.T, cr ChangeReceiver) *fixture {


### PR DESCRIPTION
- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

When two or more `AddLog` calls arrive simultaneously on a fresh database, each transaction attempts to implicitly create the `payload` collection. MongoDB cannot serialize implicit collection creation across concurrent multi-document transactions, so all but one fail with:

    (WriteConflict) Caused by :: Collection namespace 'consensus.payload' is already in use.

This affects every first-time self-hosted user: the Anytype client pushes multiple spaces in parallel on first connect, triggering concurrent `AddLog` RPCs. The result is that file sync breaks while notes work fine.

**Fix:** explicitly create all three collections (`log`, `settings`, `payload`) in `Run()` before accepting requests. `CreateCollection` is idempotent on MongoDB 7.0+; on older versions we ignore `NamespaceExists` (code 48).

I verified this by running MongoDB 4.4 and 8.0 in Docker and calling `AddLog` concurrently - without the fix 4/5 calls fail, with the fix all succeed.

### What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix
- [x] ✅ Test

### Related Tickets & Documents

Discovered while debugging file sync failure in [any-sync-bundle](https://github.com/grishy/any-sync-bundle).

### Added tests?

- [x] 👍 yes

### Added to documentation?

- [x] 🙅 no documentation needed